### PR TITLE
Option 'dirLevel' has a bug with Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Mac & Linux:
 Windows
   the plugin will use `sub_img\same.svg` to find this file in the quoted files;
 
-when you set `sep` to */*, it's same in every system platform.
+when you set `sep` to */*, it's `sub_img/same.svg`, same in every system platform.
 
 ## Demo
 

--- a/README.md
+++ b/README.md
@@ -84,19 +84,19 @@ Example:
 The sample above will append the md5 hash(length : 10) to each of the file in the static/js folder then repalce the link file name in the output/html/ using md5ed file name; at last store all of that into the *output* folder.
 
 ##### option.sep
-Type: `String` or `Function`
-Default: `require('path').sep`
+Type: `String`
+Default: `require('path').posix.sep`
 
 > use to replace file path's separator when option.dirLevel is not null.
 
 for example:
-  there is a file `Dev/work/gulp-md5-plus/demo/source/img/sub_img/same.svg`; when setting `dirLevel` to *1*,
+  there is a file `Dev/work/gulp-md5-plus/demo/source/img/sub_img/same.svg`; when setting `dirLevel` to `1`,
 Mac & Linux:
   the plugin will use `sub_img/same.svg` to find this file in the quoted files;
 Windows
   the plugin will use `sub_img\same.svg` to find this file in the quoted files;
 
-when you set `sep` to */*, it's `sub_img/same.svg`, same in every system platform.
+when you set `sep` to `/`, it's `sub_img/same.svg`, same in every system platform.
 
 ## Demo
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,21 @@ Example:
 
 The sample above will append the md5 hash(length : 10) to each of the file in the static/js folder then repalce the link file name in the output/html/ using md5ed file name; at last store all of that into the *output* folder.
 
+##### option.sep
+Type: `String` or `Function`
+Default: `require('path').sep`
+
+> use to replace file path's separator when option.dirLevel is not null.
+
+for example:
+  there is a file `Dev/work/gulp-md5-plus/demo/source/img/sub_img/same.svg`; when setting `dirLevel` to *1*,
+Mac & Linux:
+  the plugin will use `sub_img/same.svg` to find this file in the quoted files;
+Windows
+  the plugin will use `sub_img\same.svg` to find this file in the quoted files;
+
+when you set `sep` to */*, it's same in every system platform.
+
 ## Demo
 
 I have add a demo to demonstate how to use this plugin; If you have any other questions ,pls add issues.

--- a/index.js
+++ b/index.js
@@ -43,10 +43,14 @@ module.exports = function (size, ifile, option) {
         
         var l_filename = path.join(levelDir,filename);
         var l_md5_filename = path.join(levelDir,md5_filename);
-		
+
+        if (option.sep === undefined && path.sep != path.posix.sep) {
+            option.sep = path.posix.sep;
+        }
+
 		if(option.sep){
-			l_filename = replacePathSeprator(l_filename, option.sep);
-			l_md5_filename = replacePathSeprator(l_md5_filename, option.sep);
+			l_filename = replacePathSeparator(l_filename, option.sep);
+			l_md5_filename = replacePathSeparator(l_md5_filename, option.sep);
 		}
 
         if(Object.prototype.toString.call(ifile) == "[object Array]"){
@@ -106,15 +110,9 @@ function calcMd5(file, slice){
  * @param filePath file path
  * @param sep path reparator, window system path separator is special
  */
-function replacePathSeprator(filePath, sep) {
+function replacePathSeparator(filePath, sep) {
     if (filePath && sep) {
-        if (typeof sep === 'function') {
-            sep = sep(filePath);
-        }
-		
-		
-
-        if (sep && typeof sep === 'string') {
+        if (typeof sep === 'string') {
             sep = sep.substr(0, 1);
 			
 			if(sep === path.sep){

--- a/index.js
+++ b/index.js
@@ -43,10 +43,14 @@ module.exports = function (size, ifile, option) {
         
         var l_filename = path.join(levelDir,filename);
         var l_md5_filename = path.join(levelDir,md5_filename);
-		
+
+        if (option.dirLevel) {
+            levelDir = getLevelDir(dir, option.dirLevel).join(path.sep);
+        }
+
 		if(option.sep){
-			l_filename = replacePathSeprator(l_filename, option.sep);
-			l_md5_filename = replacePathSeprator(l_md5_filename, option.sep);
+			l_filename = replacePathSeparator(l_filename, option.sep);
+			l_md5_filename = replacePathSeparator(l_md5_filename, option.sep);
 		}
 
         if(Object.prototype.toString.call(ifile) == "[object Array]"){
@@ -106,15 +110,9 @@ function calcMd5(file, slice){
  * @param filePath file path
  * @param sep path reparator, window system path separator is special
  */
-function replacePathSeprator(filePath, sep) {
+function replacePathSeparator(filePath, sep) {
     if (filePath && sep) {
-        if (typeof sep === 'function') {
-            sep = sep(filePath);
-        }
-		
-		
-
-        if (sep && typeof sep === 'string') {
+        if (typeof sep === 'string') {
             sep = sep.substr(0, 1);
 			
 			if(sep === path.sep){

--- a/index.js
+++ b/index.js
@@ -43,6 +43,11 @@ module.exports = function (size, ifile, option) {
         
         var l_filename = path.join(levelDir,filename);
         var l_md5_filename = path.join(levelDir,md5_filename);
+		
+		if(option.sep){
+			l_filename = replacePathSeprator(l_filename, option.sep);
+			l_md5_filename = replacePathSeprator(l_md5_filename, option.sep);
+		}
 
         if(Object.prototype.toString.call(ifile) == "[object Array]"){
             ifile.forEach(function(i_ifile){
@@ -94,4 +99,32 @@ function calcMd5(file, slice){
     md5.update(file.contents, 'utf8');
 
     return slice >0 ? md5.digest('hex').slice(0, slice) : md5.digest('hex');
+}
+
+/**
+ * repalce the file path separator, resolve dirLevel error bug
+ * @param filePath file path
+ * @param sep path reparator, window system path separator is special
+ */
+function replacePathSeprator(filePath, sep) {
+    if (filePath && sep) {
+        if (typeof sep === 'function') {
+            sep = sep(filePath);
+        }
+		
+		
+
+        if (sep && typeof sep === 'string') {
+            sep = sep.substr(0, 1);
+			
+			if(sep === path.sep){
+				return filePath;
+			}
+
+            var reg = new RegExp('\\' + path.sep, 'g');
+            return filePath.replace(reg, sep);
+        }
+    }
+
+    return filePath;
 }


### PR DESCRIPTION
I hava some files like this:

```
build/css/main.min.css
build/js/app.min.js
```

then I put them in html files:

```
<link href="//cdn.bootcss.com/css/main.min.css" rel="stylesheet">
<link href="/css/main.min.css" rel="stylesheet">
<script src="/js/app.min.js" type="text/javascript"></script>
```

I want replace `app.min.js` and `main.min.css`, so I set `option.dirLevel = 1`.
It works fine in Mac and other Linux platform, but it's broken in Windows.

I take some logs, then I found the secrect.
Mac & Linux:
    use `js/app.min.js` to replace
Windows:
    use `js\app.min.js` to replace

So, how to resolve? add a option `sep` to replace?
