### PR TITLE
Fix getLevelDir issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ function getLevelDir(dir,level){
     if(dirs && dirs.length >= level){
         return dirs.slice(dirs.length - level)
     }else{
-        return ""
+        return []
     }
 }
 


### PR DESCRIPTION
getLevelDir should return an array in the case dirs && dirs.length >= level condition is not, this is to prevent a but stating .joinDir is not a funciton error, also it makes the function behavior to be consistent (always return an array)